### PR TITLE
fix: use proper tags for multiarch

### DIFF
--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -1,3 +1,3 @@
-FROM multiarch/alpine:latest
+FROM multiarch/alpine:armv7-latest-stable
 
 RUN apk add --update --no-cache vim bash

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -1,3 +1,3 @@
-FROM multiarch/alpine:latest
+FROM multiarch/alpine:arm64-latest-stable
 
 RUN apk add --update --no-cache vim bash


### PR DESCRIPTION
The latest tag does not exist. We need to choose a proper tag for each architecture.